### PR TITLE
[SETTING] 공통 응답 및 에러 핸들러 세팅

### DIFF
--- a/module-api/build.gradle.kts
+++ b/module-api/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework:spring-jdbc:6.2.3")
-    implementation("org.springframework.cloud:spring-cloud-starter-config")
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
     

--- a/module-api/src/main/kotlin/org/depromeet/team3/config/ControllerAdvice.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/config/ControllerAdvice.kt
@@ -1,0 +1,33 @@
+package org.depromeet.team3.config
+
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.common.exception.DpmException
+import org.depromeet.team3.common.response.DpmApiResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ *  일관된 에러 응답을 보장하기 위한 전역 예외 처리기
+ */
+@RestControllerAdvice
+class ControllerAdvice {
+
+    /**
+     * 커스텀 Exception 하위 클래스
+     */
+    @ExceptionHandler(DpmException::class)
+    fun handleDpmException(e: DpmException): ResponseEntity<DpmApiResponse<Unit>> {
+        return ResponseEntity.status(e.errorCode.httpStatus)
+            .body(DpmApiResponse.error(e))
+    }
+
+    /**
+     * 위 Exception 이 놓친 모든 예외 처리
+     */
+    @ExceptionHandler(Exception::class)
+    fun handleGenericException(e: Exception): ResponseEntity<DpmApiResponse<Unit>> {
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.httpStatus)
+            .body(DpmApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR))
+    }
+}

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -1,8 +1,11 @@
 spring:
   application:
     name: team3-api
+  
+  cloud:
+    config:
+      enabled: false
 
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
-

--- a/module-domain/src/main/kotlin/org/depromeet/team3/common/exception/DpmException.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/common/exception/DpmException.kt
@@ -1,0 +1,13 @@
+package org.depromeet.team3.common.exception
+
+
+
+/**
+ *  애플리케이션 전역 커스텀 예외 최상위 클래스
+ *  - 각 도메인 패키지에서 해당 클래스 상속하여 예외 타입 정의해서 사용하시면 됩니다.
+ */
+abstract class DpmException(     // 서비스명 확정되면 이름 수정 예정
+    val errorCode: ErrorCode,
+    val detail: Map<String, Any?>? = null,
+    message: String? = errorCode.message,
+) : Exception(message)

--- a/module-domain/src/main/kotlin/org/depromeet/team3/common/exception/ErrorCode.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/common/exception/ErrorCode.kt
@@ -1,0 +1,28 @@
+package org.depromeet.team3.common.exception
+
+/**
+ * 애플리케이션 전역에서 사용하는 에러 코드 정의
+ */
+enum class ErrorCode(
+    val code: String,
+    val message: String,
+    val httpStatus: Int
+) {
+    // 4xx Client Errors
+    INVALID_REQUEST("C001", "잘못된 요청입니다.", 400),
+    INVALID_PARAMETER("C002", "유효하지 않은 파라미터입니다.", 400),
+    MISSING_PARAMETER("C003", "필수 파라미터가 누락되었습니다.", 400),
+    INVALID_JSON("C004", "잘못된 JSON 형식입니다.", 400),
+
+    // 404 Not Found
+    RESOURCE_NOT_FOUND("C404", "요청한 리소스를 찾을 수 없습니다.", 404),
+
+    // 409 Conflict
+    RESOURCE_CONFLICT("C409", "리소스 충돌이 발생했습니다.", 409),
+    DUPLICATE_RESOURCE("C4091", "중복된 리소스입니다.", 409),
+
+    // 5xx Server Errors
+    INTERNAL_SERVER_ERROR("S001", "서버 내부 오류가 발생했습니다.", 500),
+    DATABASE_ERROR("S002", "데이터베이스 오류가 발생했습니다.", 500),
+    EXTERNAL_API_ERROR("S003", "외부 API 호출 중 오류가 발생했습니다.", 500)
+}

--- a/module-domain/src/main/kotlin/org/depromeet/team3/common/response/DpmApiResponse.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/common/response/DpmApiResponse.kt
@@ -1,0 +1,26 @@
+package org.depromeet.team3.common.response
+
+import org.depromeet.team3.common.exception.DpmException
+import org.depromeet.team3.common.exception.ErrorCode
+
+/**
+ *  모든 API 응답을 감싸는 공통 Wrapper 클래스
+ */
+data class DpmApiResponse<T>(     // 서비스명 확정되면 이름 수정할 예정
+    val data: T? = null,      // 성공 시 내려줄 데이터
+    val error: ErrorResponse? = null,    // 실패 시 내려줄 에러 정보
+) {
+    companion object {
+        fun <T> ok(data: T): DpmApiResponse<T> =
+            DpmApiResponse(data = data)
+
+        fun ok(): DpmApiResponse<Unit> =
+            DpmApiResponse(data = Unit)
+
+        fun error(errorCode: ErrorCode, detail: Map<String, Any?>? = null): DpmApiResponse<Unit> =
+            DpmApiResponse(error = ErrorResponse.from(errorCode, detail))
+
+        fun error(e: DpmException): DpmApiResponse<Unit> =
+            error(e.errorCode, e.detail)
+    }
+}

--- a/module-domain/src/main/kotlin/org/depromeet/team3/common/response/ErrorResponse.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/common/response/ErrorResponse.kt
@@ -1,0 +1,22 @@
+package org.depromeet.team3.common.response
+
+import org.depromeet.team3.common.exception.ErrorCode
+
+data class ErrorResponse(
+    val name: String,
+    val code: String,
+    val message: String? = null,
+    val detail: Map<String, Any?>? = null
+) {
+
+    companion object {
+        fun from(errorCode: ErrorCode, detail: Map<String, Any?>? = null): ErrorResponse {
+            return ErrorResponse(
+                name = errorCode.name,
+                code = errorCode.code,
+                message = errorCode.message,
+                detail = detail
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #5 

## 🔑 주요 내용

```
module-domain: 도메인 로직과 공통 예외/응답 모델 정의
module-api: API 레이어와 전역 예외 처리기 구현
```

어플리케이션단 전역에서 사용할 공통 응답 및 에러 핸들러 세팅하였습니다. 
(커스텀 예외와 응답 클래스는 서비스명 확정되는 대로 수정할게용 !)

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - API 에러 응답을 표준화했습니다. 일관된 에러 코드, 메시지, HTTP 상태로 응답하며 성공/실패 포맷이 통일됩니다.
  - 일반 예외에 대한 글로벌 처리로 예외 상황에서도 예측 가능한 응답을 제공합니다.
- Chores
  - 외부 구성 서버 연동을 비활성화하여 실행 안정성을 개선했습니다.
  - 관련 의존성을 정리해 불필요한 구성 요소를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->